### PR TITLE
Make the driver a required nodelet since... it is

### DIFF
--- a/launch/includes/device.launch.xml
+++ b/launch/includes/device.launch.xml
@@ -30,7 +30,8 @@
   <!-- Driver nodelet -->
   <node pkg="nodelet" type="nodelet" name="driver"
         args="load astra_camera/AstraDriverNodelet $(arg manager)"
-	    respawn="$(arg respawn)">
+        required="true"
+        respawn="$(arg respawn)">
     <param name="device_id" type="str" value="$(arg device_id)" />
     <param name="bootorder" type="int" value="$(arg bootorder)" />
     <param name="devnums" type="int" value="$(arg devnums)" />


### PR DESCRIPTION
This will also allow systemd to manage the shutdown, restart, and
recovery of the cameras individually if the driver can't find the
device.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/ros_astra_launch/2)
<!-- Reviewable:end -->
