### PR TITLE
Clear namespace from param server prior to launching driver

### DIFF
--- a/launch/includes/device.launch.xml
+++ b/launch/includes/device.launch.xml
@@ -30,8 +30,7 @@
   <!-- Driver nodelet -->
   <node pkg="nodelet" type="nodelet" name="driver"
         args="load astra_camera/AstraDriverNodelet $(arg manager)"
-        required="true"
-        respawn="$(arg respawn)">
+        clear_params="true" required="true" respawn="$(arg respawn)">
     <param name="device_id" type="str" value="$(arg device_id)" />
     <param name="bootorder" type="int" value="$(arg bootorder)" />
     <param name="devnums" type="int" value="$(arg devnums)" />


### PR DESCRIPTION
The depthcamera extrinsic calibration procedure sets parameters on the depthcamera's namespace. In the event of the calibration service failing prior to resetting these parameters, the parameter server will be left in a bad state, even after restarting the depthcamera services.

This pull request resolves this by deleting the depthcamera's namespace from the param server prior to launch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/ros_astra_launch/3)
<!-- Reviewable:end -->
