### PR TITLE
Revert default camera intrinsics commits

### DIFF
--- a/launch/astrapro.launch
+++ b/launch/astrapro.launch
@@ -20,8 +20,8 @@
   <!-- By default, calibrations are stored to file://${ROS_HOME}/camera_info/${NAME}.yaml,
        where ${NAME} is of the form "[rgb|depth]_[serial#]", e.g. "depth_B00367707227042B".
        See camera_info_manager docs for calibration URL details. -->
-  <arg name="rgb_camera_info_url"   default="file://$(env BAR_CONFIG)/depthcams/$(arg camera)_rgb_intrinsics.yaml" />
-  <arg name="depth_camera_info_url" default="file://$(env BAR_CONFIG)/depthcams/$(arg camera)_intrinsics.yaml" />
+  <arg name="rgb_camera_info_url"   default="" />
+  <arg name="depth_camera_info_url" default="" />
 
   <!-- Hardware depth registration -->
   <arg name="depth_registration" default="false" />


### PR DESCRIPTION
The two camera intrinsics parameters modified in the last two commits should
really be set by bar_launchers.

The depth intrinsics are already specified upstream in bar_launchers, so the
default parameter set here has no effect. Furthermore, the default parameter
here references a file location name that differs from upstream, which is
confusing.

The RGB camera intrinsics should also be specified upstream. In addition to
reverting the commits here, a default overrides will be specified in
bar_launchers in a separate bar_launchers commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/ros_astra_launch/6)
<!-- Reviewable:end -->
