### PR TITLE
Set RGB stream format properly for gemini2

### DIFF
--- a/launch/includes/orbbec-ros-sdk.launch.xml
+++ b/launch/includes/orbbec-ros-sdk.launch.xml
@@ -22,18 +22,21 @@
   <arg name="enable_depth" default="true" />
   <arg name="enable_rgb" default="true" />
   <arg name="enable_ir" default="true" />
+
   <arg name="depth_width" default="$(eval 160 if product_id == astra_mini_pro else 320)" />
   <arg name="depth_height" default="$(eval 120 if product_id == astra_mini_pro else 200)" />
   <arg name="depth_fps" default="30" />
+  <arg name="depth_format" default="$(eval 'Y12' if product_id == astra_mini_pro else 'Y14' if product_id == gemini2 else 'Y16')" />
+
   <arg name="ir_width" default="1280" />
   <arg name="ir_height" default="$(eval 800 if product_id == gemini2 else 1024)" />
   <arg name="ir_fps" default="$(eval 7 if product_id == astra_mini_pro else 30 if product_id == gemini2 else 5)" />
+  <arg name="ir_format" default="$(eval 'Y8' if product_id == gemini2 else 'Y10')" />
+
   <arg name="rgb_width" default="640" />
   <arg name="rgb_height" default="480" />
   <arg name="rgb_fps" default="30" />
-  <arg name="depth_format" default="$(eval 'Y12' if product_id == astra_mini_pro else 'Y14' if product_id == gemini2 else 'Y16')" />
-  <arg name="ir_format" default="$(eval 'Y8' if product_id == gemini2 else 'Y10')" />
-  <arg name="rgb_format" default="RGB" />
+  <arg name="rgb_format" default="${eval 'YUYV' if product_id == gemini2 else 'RGB'}" />
 
   <arg name="depth_registration" default="false" />
   <arg name="enable_d2c_viewer" default="false"/>


### PR DESCRIPTION
The RGB format for all cameras using the orbbec driver is RGB.

This is invalid for Gemini2 cameras and was causing distoritions in the image. Not sure why this was silently failing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/ros_astra_launch/10)
<!-- Reviewable:end -->
