### PR TITLE
Fix eval statement in RGB format

### DIFF
--- a/launch/includes/orbbec-ros-sdk.launch.xml
+++ b/launch/includes/orbbec-ros-sdk.launch.xml
@@ -36,7 +36,7 @@
   <arg name="rgb_width" default="640" />
   <arg name="rgb_height" default="480" />
   <arg name="rgb_fps" default="30" />
-  <arg name="rgb_format" default="${eval 'YUYV' if product_id == gemini2 else 'RGB'}" />
+  <arg name="rgb_format" default="$(eval 'YUYV' if product_id == gemini2 else 'RGB')" />
 
   <arg name="depth_registration" default="false" />
   <arg name="enable_d2c_viewer" default="false"/>


### PR DESCRIPTION
The braces in the eval statement should be parenthesis. This was causing the value to not evaluate and simply be the string of the eval statement.

ROS-1843: Orbbec driver depthcam rgb_format default eval
  statement is written incorrectly, not evaluating.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/ros_astra_launch/12)
<!-- Reviewable:end -->
