### PR TITLE
Fix stream setting for gemini 2

### DIFF
--- a/launch/includes/gemini2.launch.xml
+++ b/launch/includes/gemini2.launch.xml
@@ -26,7 +26,7 @@
   <arg name="depth_width" default="320" />
   <arg name="depth_height" default="200" />
   <arg name="depth_fps" default="30" />
-  <arg name="depth_format" default="Y16" />
+  <arg name="depth_format" default="Y14" />
   <arg name="depth_ae_roi_left" default="20"/>
   <arg name="depth_ae_roi_right" default="300"/>
   <arg name="depth_ae_roi_top" default="25"/>


### PR DESCRIPTION
After updating the Gemini 2 to the lastest driver version, Y16 is no longer an acceptable encoding format for the depth stream. Change it to Y14, which is.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/ros_astra_launch/14)
<!-- Reviewable:end -->
