### PR TITLE
Switch backend to v4l2

### DIFF
--- a/launch/includes/gemini2.launch.xml
+++ b/launch/includes/gemini2.launch.xml
@@ -19,14 +19,14 @@
   <arg name="enable_rgb" default="true" />
   <arg name="enable_ir" default="true" />
 
-  <arg name="uvc_backend" default="libuvc"/><!-- "libuvc" or "v4l2" -->
+  <arg name="uvc_backend" default="v4l2"/><!-- "libuvc" or "v4l2" -->
   <arg name="device_preset" default="Default"/>
 
   <!-- Depth Stream Settings-->
   <arg name="depth_width" default="320" />
   <arg name="depth_height" default="200" />
   <arg name="depth_fps" default="30" />
-  <arg name="depth_format" default="Y14" />
+  <arg name="depth_format" default="Y16" />
   <arg name="depth_ae_roi_left" default="20"/>
   <arg name="depth_ae_roi_right" default="300"/>
   <arg name="depth_ae_roi_top" default="25"/>


### PR DESCRIPTION
V4L2 provides improved performance and lower resource consumption as compared to the default backend of libUVC.

This also should fix an intermittent issue with dropped frames and an intermittent buffer overflow error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/ros_astra_launch/15)
<!-- Reviewable:end -->
