### PR TITLE
Daylight the depth_format parameter for gemini2 launches

### DIFF
--- a/launch/astrapro.launch
+++ b/launch/astrapro.launch
@@ -61,6 +61,7 @@
   <arg name="sw_registered_processing"        default="false" if="$(arg depth_registration)" />
   <arg name="hw_registered_processing"        default="false" unless="$(arg depth_registration)" />
   <arg name="sw_registered_processing"        default="true" unless="$(arg depth_registration)" />
+  <arg name="gemini2_depth_format"            default="Y16" />
 
   <!-- Disable bond topics by default -->
   <arg name="respawn" default="false" />
@@ -141,6 +142,7 @@
       <arg name="required"                        value="$(arg required)" />
       <arg name="depth_registration"              value="$(arg depth_registration)" />
       <arg name="lockfile"                        value="$(arg lockfile)" />
+      <arg name="depth_format"                    value="$(arg gemini2_depth_format)" />
     </include>
 
     <!-- Load standard constellation of processing nodelets -->


### PR DESCRIPTION
On Gemini 2 cameras, firmware 1.4.98 requires that this value be set to "Y16". Prior versions of the firmware required that this value be set to "RLE". In either case, the driver will not successfully start unless the correct value has been specified. Therefore, allow calls to roslaunch to specify this parameter at the top level so that the same launch file can be used in both cases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/ros_astra_launch/16)
<!-- Reviewable:end -->
