### PR TITLE
Turn on filters

### DIFF
--- a/launch/includes/gemini2.launch.xml
+++ b/launch/includes/gemini2.launch.xml
@@ -20,7 +20,6 @@
   <arg name="enable_ir" default="true" />
 
   <arg name="uvc_backend" default="v4l2"/><!-- "libuvc" or "v4l2" -->
-  <arg name="device_preset" default="Default"/>
 
   <!-- Depth Stream Settings-->
   <arg name="depth_width" default="320" />
@@ -31,6 +30,13 @@
   <arg name="depth_ae_roi_right" default="300"/>
   <arg name="depth_ae_roi_top" default="25"/>
   <arg name="depth_ae_roi_bottom" default="120"/>
+
+  <!-- Depth work mode support is as follows： -->
+  <!-- Unbinned Dense Default -->
+  <!-- Unbinned Sparse Default -->
+  <!-- Binned Sparse Default -->
+  <!-- Obstacle Avoidance -->
+  <arg name="depth_work_mode" default="Unbinned Dense Default"/>
 
   <!-- IR Stream Settings -->
   <arg name="enable_ir_auto_exposure" default="true"/>
@@ -86,7 +92,6 @@
     <param name="enable_rgb" value="$(arg enable_rgb)" />
 
     <param name="uvc_backend" value="$(arg uvc_backend)"/>
-    <param name="device_preset" value="$(arg device_preset)"/>
 
     <!-- Depth Stream Settings-->
     <param name="depth_width" value="$(arg depth_width)" />
@@ -97,6 +102,8 @@
     <param name="depth_ae_roi_right" value="$(arg depth_ae_roi_right)"/>
     <param name="depth_ae_roi_top" value="$(arg depth_ae_roi_top)"/>
     <param name="depth_ae_roi_bottom" value="$(arg depth_ae_roi_bottom)"/>
+
+    <param name="depth_work_mode" value="$(arg depth_work_mode)"/>
 
     <!-- IR Stream Settings -->
     <param name="enable_ir_auto_exposure" value="$(arg enable_ir_auto_exposure)"/>

--- a/launch/includes/gemini2.launch.xml
+++ b/launch/includes/gemini2.launch.xml
@@ -38,6 +38,23 @@
   <!-- Obstacle Avoidance -->
   <arg name="depth_work_mode" default="Unbinned Dense Default"/>
 
+  <!-- Noise Removal Filter -->
+  <arg name="enable_noise_removal_filter" default="true"/>
+  <arg name="noise_removal_filter_min_diff" default="400"/>
+  <arg name="noise_removal_filter_max_size" default="240"/>
+
+  <!-- Temporal Filter -->
+  <arg name="enable_temporal_filter" default="true"/>
+  <arg name="temporal_filter_diff_threshold" default="0.1"/>
+  <arg name="temporal_filter_weight" default="0.35"/>
+
+  <!-- Spatial Filter -->
+  <arg name="enable_spatial_filter" default="true"/>
+  <arg name="spatial_filter_alpha" default="0.5"/>
+  <arg name="spatial_filter_diff_threshold" default="1"/>
+  <arg name="spatial_filter_magnitude" default="2"/>
+  <arg name="spatial_filter_radius" default="1"/>
+
   <!-- IR Stream Settings -->
   <arg name="enable_ir_auto_exposure" default="true"/>
   <arg name="ir_width" default="1280" />
@@ -92,6 +109,23 @@
     <param name="enable_rgb" value="$(arg enable_rgb)" />
 
     <param name="uvc_backend" value="$(arg uvc_backend)"/>
+
+    <!-- Noise Removal Filter -->
+    <param name="enable_noise_removal_filter" value="$(arg enable_noise_removal_filter)"/>
+    <param name="noise_removal_filter_min_diff" value="$(arg noise_removal_filter_min_diff)"/>
+    <param name="noise_removal_filter_max_size" value="$(arg noise_removal_filter_max_size)"/>
+
+    <!-- Temporal Filter -->
+    <param name="enable_temporal_filter" value="$(arg enable_temporal_filter)"/>
+    <param name="temporal_filter_diff_threshold" value="$(arg temporal_filter_diff_threshold)"/>
+    <param name="temporal_filter_weight" value="$(arg temporal_filter_weight)"/>
+
+    <!-- Spatial Filter -->
+    <param name="enable_spatial_filter" value="$(arg enable_spatial_filter)"/>
+    <param name="spatial_filter_alpha" value="$(arg spatial_filter_alpha)"/>
+    <param name="spatial_filter_diff_threshold" value="$(arg spatial_filter_diff_threshold)"/>
+    <param name="spatial_filter_magnitude" value="$(arg spatial_filter_magnitude)"/>
+    <param name="spatial_filter_radius" value="$(arg spatial_filter_radius)"/>
 
     <!-- Depth Stream Settings-->
     <param name="depth_width" value="$(arg depth_width)" />


### PR DESCRIPTION
Fix the 'depth_work_mode' arg. I accidentally used the 'device_preset' name which is for the Gemini 3 series.

Turn on the Temporal/Spatial filter by default. This is mainly to address the extreme noise seen around the edges and in the far corners of the depth image. This noise caused us to have to increase the RANSAC distance threshold which allowed for more of this noise to be included in the floor template. With the light filtering I have set in these fitlers I have been able to reduce the threshold back down to the previous setting. This should also allow us to turn down some of the aggressive cropping done to the depth images in the proximity/pristine filters.

Increase the max size of blobs to remove and the threshold required to declare them noise for the Noise Removal Filter. This filter is already on. This is to address the intermittent noise around the tower that I saw affecting some bots ability to navigate (1656 was the prime example, although I havent been able to re-create it recently).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/ros_astra_launch/17)
<!-- Reviewable:end -->
