### PR TITLE
Turn off onboard noise removal filter

### DIFF
--- a/launch/includes/gemini2.launch.xml
+++ b/launch/includes/gemini2.launch.xml
@@ -39,7 +39,7 @@
   <arg name="depth_work_mode" default="Obstacle Avoidance"/>
 
   <!-- Noise Removal Filter -->
-  <arg name="enable_noise_removal_filter" default="true"/>
+  <arg name="enable_noise_removal_filter" default="$(eval optparam(arg('camera_name') + '/driver/enable_noise_removal_filter', true))"/>
   <arg name="noise_removal_filter_min_diff" default="$(eval optparam(arg('camera_name') + '/driver/noise_removal_filter_min_diff', 240))"/>
   <arg name="noise_removal_filter_max_size" default="20"/>
 


### PR DESCRIPTION
The onboard noise removal filter is removing necessary valid data of small objects like mesh. Instead we will use an inhouse outlier filter.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/ros_astra_launch/20)
<!-- Reviewable:end -->
